### PR TITLE
Superscript the theme version number

### DIFF
--- a/src/theme/misc/_watermarks.scss
+++ b/src/theme/misc/_watermarks.scss
@@ -27,10 +27,10 @@
   &::after {
     content: $version;
     position: static;
-    margin-top: 3px;
+    margin-top: -5px;
     margin-left: 5px;
     font-family: cv('font.code');
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 600;
     color: cv('text.muted');
     order: 3;


### PR DESCRIPTION
# What was changed
Move the version number on the titlebar watermark up (superscript) to be more in line with how it was on ClearVision-v6

## Additional Notes
I doubt this will get merged but no harm in opening a pull request

## Images
**Before**
![Before](https://github.com/user-attachments/assets/a22fbb48-a12a-48e3-bbb6-024f2b31dca4)
**After**
![After](https://github.com/user-attachments/assets/8a774c4a-fa76-4320-a65c-6ed553fe55ac)

